### PR TITLE
Move tests into their own folder

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "jest",
     "start": "node dist/index.js",
-    "build": "tsc -b",
+    "build": "tsc --project tsconfig.build.json",
     "dev": "nodemon dist/index.js"
   },
   "keywords": [],

--- a/backend/src/sum.ts
+++ b/backend/src/sum.ts
@@ -1,3 +1,11 @@
+/**
+ * Returns the sum of two numbers.
+ * 
+ * Not for production use, testing purposes only.
+ * @param a First number to add
+ * @param b Second number to add
+ * @returns The sum of a and b
+ */
 export function sum( a: number, b: number){
     return a + b;
 }

--- a/backend/tests/sum.test.ts
+++ b/backend/tests/sum.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, test} from '@jest/globals';
-import {sum} from './sum';
+import {sum} from '../src/sum';
 
 describe('sum module', () => {
   test('adds 1 + 2 to equal 3', () => {

--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [ "tests/**/*" ]
+}

--- a/frontend/src/sum.ts
+++ b/frontend/src/sum.ts
@@ -1,3 +1,11 @@
+/**
+ * Returns the sum of two numbers.
+ * 
+ * Not for production use, testing purposes only.
+ * @param a First number to add
+ * @param b Second number to add
+ * @returns The sum of a and b
+ */
 export function sum( a: number, b: number){
     return a + b;
 }

--- a/frontend/tests/sum.test.ts
+++ b/frontend/tests/sum.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, test} from '@jest/globals';
-import {sum} from './sum';
+import {sum} from '../src/sum';
 
 describe('sum module', () => {
   test('adds 1 + 2 to equal 3', () => {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "esModuleInterop": true,
 
     /* Bundler mode */
     "moduleResolution": "bundler",
@@ -20,6 +21,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"],
+  "include": ["src", "tests/*"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
This PR moves tests so that they are in their own dedicated folder outside of `src`

This also prevents backend tests from being included in production code. It has not yet been tested as to whether frontend tests get included in production code as well or not.