### PR TITLE
fix: include *.env in git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,8 @@
 
 # misc
 .DS_Store
-/frontend/.env
-/backend/.env
+/frontend/*.env
+/backend/*.env
 .env.local
 .env.development.local
 .env.test.local


### PR DESCRIPTION
modify git ignore to include all files ending in .env