### PR TITLE
Fix Deploy Errors, Add Build CI Job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,41 @@
 name: PR
 on: [pull_request]
 jobs:
+  build:
+    # TODO: Ideally this could *actually* build production-ready files. Maybe for Sprint 2?
+    runs-on: ubuntu-latest
+    steps:
+      - name: Chekout Repository
+        uses: actions/checkout@v3
+
+      - name: Install Node.JS v18 For Frontend
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      
+      - name: Check Frontend Build
+        run: |
+          cd frontend
+          npm ci
+          tsc --noEmit
+
+      - name: Install Node.JS v18 For Backend
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+      
+      - name: Check Backend Build
+        run: |
+          cd backend
+          npm ci
+          tsc --noEmit
+
   lint:
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -21,6 +55,7 @@ jobs:
       - name: Run ESLint
         run: npm run lint
   tests:
+    needs: build
     runs-on: ubuntu-latest
     environment: Staging
     steps:

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,7 +5,7 @@ import cors from 'cors';
 import dotenv from 'dotenv';
 import cookieParser from 'cookie-parser';
 import jwt from 'jsonwebtoken';
-// import User from './models/user.js'
+
 // load our .env file
 import { fetchAllBooks, fetchBookByISBN, fetchBookCount } from './models/book';
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -17,7 +17,11 @@ app.use(express.json());
 app.use(cookieParser());
 app.use(
   cors({
-    origin: ['http://localhost:5173', 'http://localhost:80', 'https://capstone.caseycodes.dev'],
+    origin: [
+      'http://localhost:5173',
+      'http://localhost:80',
+      'https://capstone.caseycodes.dev'
+    ],
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
     credentials: true
   })

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -18,7 +18,7 @@ app.use(cookieParser());
 app.use(
   cors({
     origin: 'http://localhost:5173',
-    methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
+    methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
     credentials: true
   })
 );

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -17,7 +17,7 @@ app.use(express.json());
 app.use(cookieParser());
 app.use(
   cors({
-    origin: 'http://localhost:5173',
+    origin: ['http://localhost:5173', 'http://localhost:80', 'https://capstone.caseycodes.dev'],
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
     credentials: true
   })
@@ -63,7 +63,7 @@ const User: Model<IUser & Document> = mongoose.model<IUser & Document>(
 export default User;
 
 // Handle registration form submission
-app.post('/register', async (req: Request, res: Response) => {
+app.post('/api/register', async (req: Request, res: Response) => {
   const { username, email, password, confirmPassword } = req.body;
 
   // Check input password

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -39,7 +39,8 @@ function Home(): JSX.Element {
     Dive into a vibrant community of book enthusiasts and bibliophiles as you embark on a literary journey like no other. 
     Bookworm isn't just a social media app; it's a sanctuary for readers, a digital haven for bookworms of all kinds.`;
 
-  const onSearch = () => {};
+  // TODO: Commented-out as it was preventing TypeScript compilation. Could use for search functionality?
+  // const onSearch = () => {};
 
   // const { auth, username, handleSignout } = useAuth();
   const { auth, username, handleSignout } = useAuth();

--- a/frontend/src/pages/SignUp.tsx
+++ b/frontend/src/pages/SignUp.tsx
@@ -1,7 +1,7 @@
 // Import necessary libraries
 import React, { useState } from 'react';
-import axios from 'axios';
 import './signup-styles.css';
+import { submitRegistrationData } from '../services';
 
 function SignUp() {
   const [formData, setFormData] = useState({
@@ -24,10 +24,7 @@ function SignUp() {
     }
 
     try {
-      const response = await axios.post(
-        'http://localhost:3001/api/register',
-        formData
-      );
+      const response = await submitRegistrationData<typeof formData>(formData);
       alert(response.data.message);
     } catch (error) {
       alert('Registration failed. User may already exist.');

--- a/frontend/src/pages/SignUp.tsx
+++ b/frontend/src/pages/SignUp.tsx
@@ -10,11 +10,11 @@ function SignUp() {
     confirmPassword: ''
   });
 
-  const handleChange = (e) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFormData({ ...formData, [e.target.name]: e.target.value });
   };
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
     if (formData.password !== formData.confirmPassword) {

--- a/frontend/src/pages/SignUp.tsx
+++ b/frontend/src/pages/SignUp.tsx
@@ -25,7 +25,7 @@ function SignUp() {
 
     try {
       const response = await axios.post(
-        'http://localhost:3001/register',
+        'http://localhost:3001/api/register',
         formData
       );
       alert(response.data.message);

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -2,7 +2,11 @@ import axios from 'axios';
 
 // TODO: Ideally, this would reference the backend environment variables
 const PORT = 3001;
-const BASE_URL = `http://localhost:${PORT}/api`;
+
+// We need this so that development builds don't make API calls on production,
+// and so that production doesn't reference localhost as in the end user's
+// machine via the browser.
+const BASE_URL = import.meta.env.DEV ? `http://localhost:${PORT}/api`: 'https://capstone.caseycodes.dev/api';
 
 export type IBook = {
   Title: string;

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -64,3 +64,11 @@ export async function fetchHome() {
   const res = await axios.get(`${BASE_URL}`);
   return res;
 }
+
+// Registers a new user by submitted form data
+export async function submitRegistrationData<T>(formData: T) {
+  return await axios.post(
+    `${BASE_URL}/register`,
+    formData
+  );
+}

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -6,7 +6,9 @@ const PORT = 3001;
 // We need this so that development builds don't make API calls on production,
 // and so that production doesn't reference localhost as in the end user's
 // machine via the browser.
-const BASE_URL = import.meta.env.DEV ? `http://localhost:${PORT}/api`: 'https://capstone.caseycodes.dev/api';
+const BASE_URL = import.meta.env.DEV
+  ? `http://localhost:${PORT}/api`
+  : 'https://capstone.caseycodes.dev/api';
 
 export type IBook = {
   Title: string;
@@ -67,8 +69,5 @@ export async function fetchHome() {
 
 // Registers a new user by submitted form data
 export async function submitRegistrationData<T>(formData: T) {
-  return await axios.post(
-    `${BASE_URL}/register`,
-    formData
-  );
+  return axios.post(`${BASE_URL}/register`, formData);
 }


### PR DESCRIPTION
This PR fixes a couple small issues that prevented TypeScript from compiling on the frontend. This PR also introduces a new CI job that checks the build status of both the frontend and backend for every PR.

This PR also updates the styling of the signup page.

**Tasks:**

- [x] Fix frontend build errors
- [x] Add `build` CI job
- [x] Add Genyuan's sign-up CSS
- [x] Patch production to run via frontend dev server
- [x] Update production `.env` to use locally hosted mongodb instead of atlas
- [x] Patch production to run via built html/js files
- [x] Synchronize production files to this branch, and merge