### PR TITLE
Database logic cleanup

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -5,7 +5,7 @@ This directory contains all the source code relating to the backend of Bookworm.
 ## Starting the Backend
 
 1. locate to backend directory, create a .env file and define your MongoDB connection URL:
-2. paste MONGODB_URI=your MongoDB connection URL(no quotation mark, just URL)
+2. paste DATABASE_URL=your MongoDB connection URL(no quotation mark, just URL)
    PORT=3001
 3. Open a terminal, and ensure that you are in the `backend` directory
 4. Run `npm i`

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -42,6 +42,8 @@ db.on('error', (error) => {
 db.once('open', () => {
   console.log('Connected to MongoDB');
 });
+
+// TODO: This should not be here. This should be imported from models/user.ts instead
 // Define user model. Email address is the primary, username should be unique too.
 interface IUser {
   username: string;
@@ -49,17 +51,20 @@ interface IUser {
   password: string;
 }
 
+// TODO: This should not be here. This should be imported from models/user.ts instead
 const userSchema: Schema<IUser & Document> = new Schema({
   username: { type: String, unique: true },
   email: { type: String, unique: true },
   password: String
 });
 
+// TODO: This should not be here. This should be imported from models/user.ts instead
 const User: Model<IUser & Document> = mongoose.model<IUser & Document>(
   'User',
   userSchema
 );
 
+// TODO: This should not be here. This should be exported from models/user.ts instead
 export default User;
 
 // Handle registration form submission
@@ -70,6 +75,8 @@ app.post('/register', async (req: Request, res: Response) => {
   if (password !== confirmPassword) {
     return res.status(400).json({ error: 'Passwords do not match.' });
   }
+
+  // TODO: All of the following code should be abstracted away in models/user.ts instead. Maybe inside of a "registerUser" function?
 
   // Password hashing and salting, use bcrypt
   const saltRounds = 10;
@@ -90,6 +97,7 @@ app.post('/register', async (req: Request, res: Response) => {
 });
 
 // Define an interface named DecodedToken
+// TODO: This should not be here. This should be imported from models/user.ts instead
 interface DecodedToken {
   name: string;
   iat: number;
@@ -117,6 +125,8 @@ app.get('/api', (req, res) => {
 app.post('/api/sign-in', async (req, res) => {
   try {
     const { email, password } = req.body.val;
+
+    // TODO: All of the following logic should be in models/user.ts instead. Maybe under a "signInUser" function?
     // Find the user in the database
     const user = await User.findOne({ email });
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -24,14 +24,14 @@ app.use(
 );
 
 // Define the MongoDB connection URL
-const mongodbUri = process.env.MONGODB_URI;
+const dbUrl = process.env.DATABASE_URL;
 
-if (!mongodbUri) {
+if (!dbUrl) {
   console.error('MongoDB connection URL is missing in the .env file.');
   process.exit(1);
 }
 
-mongoose.connect(mongodbUri);
+mongoose.connect(dbUrl);
 
 const db = mongoose.connection;
 

--- a/backend/src/models/book.ts
+++ b/backend/src/models/book.ts
@@ -6,8 +6,8 @@ const DATABASE_URL = process.env.DATABASE_URL ?? '';
 
 // TODO: change capitalization in the db
 interface Ibook {
-  Title: string;
-  Author: string;
+  title: string;
+  author: string;
   isbn: string;
   page_count: number;
   publication_date: Date;
@@ -16,8 +16,8 @@ interface Ibook {
 }
 
 const bookSchema = new Schema<Ibook>({
-  Title: { type: String, required: true },
-  Author: { type: String, required: true },
+  title: { type: String, required: true },
+  author: { type: String, required: true },
   isbn: { type: String, required: true },
   page_count: { type: Number, required: true },
   publication_date: { type: Date, required: true },

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -4,9 +4,10 @@ import axios from 'axios';
 const PORT = 3001;
 const BASE_URL = `http://localhost:${PORT}/api`;
 
+// TODO: Duplicate code
 export type IBook = {
-  Title: string;
-  Author: string;
+  title: string;
+  author: string;
   isbn: string;
   page_count: number;
   publication_date: Date;


### PR DESCRIPTION
This chore PR removes the need for two different mongodb urls, opting to instead use one single `DATABASE_URL` environment variable. For testing local dev builds, this should point to something like atlas. On production, this should point to the mongodb installed on the server.

This PR also introduces a breaking change by changing the capitalization of the `Title` and `Author` fields of `Book` to be `title` and `author` respectively.

Closes #34 