### PR TITLE
Change review box icons to use review author icons

### DIFF
--- a/frontend/src/components/ReviewBox.tsx
+++ b/frontend/src/components/ReviewBox.tsx
@@ -1,7 +1,7 @@
 import { useParams } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 
-import { List, Typography, Avatar, Button, ConfigProvider, Flex } from 'antd';
+import { List, Typography, Button, ConfigProvider, Flex } from 'antd';
 import TextArea from 'antd/es/input/TextArea';
 import {
   IReview,
@@ -12,6 +12,7 @@ import {
 } from '../services';
 import styles from './ReviewBox.module.css';
 import useAuth from '../pages/UserAuth';
+import ShowUserAvatar from './ShowUserAvatar';
 
 type PaginationPosition = 'top' | 'bottom' | 'both';
 
@@ -166,11 +167,8 @@ export default function ReviewBox(): JSX.Element {
         renderItem={(review) => (
           <List.Item>
             <List.Item.Meta
-              // TODO: Replace this with user's pfp
               avatar={
-                <Avatar
-                  src={`https://covers.openlibrary.org/b/isbn/${isbn}-S.jpg`}
-                />
+                <ShowUserAvatar name={review.username}/>
               }
               title={
                 <Flex justify='space-between'>

--- a/frontend/src/components/ReviewBox.tsx
+++ b/frontend/src/components/ReviewBox.tsx
@@ -167,9 +167,7 @@ export default function ReviewBox(): JSX.Element {
         renderItem={(review) => (
           <List.Item>
             <List.Item.Meta
-              avatar={
-                <ShowUserAvatar name={review.username} size={32}/>
-              }
+              avatar={<ShowUserAvatar name={review.username} size={32} />}
               title={
                 <Flex justify='space-between'>
                   <Typography.Text>{review.username}</Typography.Text>

--- a/frontend/src/components/ReviewBox.tsx
+++ b/frontend/src/components/ReviewBox.tsx
@@ -168,7 +168,7 @@ export default function ReviewBox(): JSX.Element {
           <List.Item>
             <List.Item.Meta
               avatar={
-                <ShowUserAvatar name={review.username}/>
+                <ShowUserAvatar name={review.username} size={32}/>
               }
               title={
                 <Flex justify='space-between'>

--- a/frontend/src/components/ShowUserAvatar.tsx
+++ b/frontend/src/components/ShowUserAvatar.tsx
@@ -3,10 +3,11 @@ import React from 'react';
 import { useParams } from 'react-router-dom';
 
 type UserAvatarProps = {
-  name?: string
+  name?: string,
+  size?: number,
 }
 
-const ShowUserAvatar: React.FC<UserAvatarProps> = ({ name }) => {
+const ShowUserAvatar: React.FC<UserAvatarProps> = ({ name, size }) => {
   // Get the first character of the username
   // If no name is provided to the component, use
   // the useParams hook to get the username from the route.
@@ -24,11 +25,12 @@ const ShowUserAvatar: React.FC<UserAvatarProps> = ({ name }) => {
     ? username.charAt(0).toUpperCase()
     : undefined;
 
+  let finalSize = size ?? 128;
   return (
     <Avatar
-      size={128}
+      size={finalSize}
       shape='square'
-      style={{ backgroundColor: '#fde3cf', color: '#f56a00', fontSize: '64px' }}
+      style={{ backgroundColor: '#fde3cf', color: '#f56a00', fontSize: `${finalSize/2}px` }}
     >
       {firstCharacter}
     </Avatar>

--- a/frontend/src/components/ShowUserAvatar.tsx
+++ b/frontend/src/components/ShowUserAvatar.tsx
@@ -2,10 +2,24 @@ import { Avatar } from 'antd';
 import React from 'react';
 import { useParams } from 'react-router-dom';
 
-const ShowUserAvatar: React.FC = () => {
+type UserAvatarProps = {
+  name?: string
+}
+
+const ShowUserAvatar: React.FC<UserAvatarProps> = ({ name }) => {
   // Get the first character of the username
-  // Use the useParams hook to get the username from the route
-  const { username } = useParams<{ username?: string }>();
+  // If no name is provided to the component, use
+  // the useParams hook to get the username from the route.
+  // Else, use the username passed to the component
+  let username: string | undefined;
+  if (!name) {
+    let params = useParams<{ username?: string }>();
+    username = params.username;
+  }
+  else {
+    username = name;
+  }
+  
   const firstCharacter: string | undefined = username
     ? username.charAt(0).toUpperCase()
     : undefined;

--- a/frontend/src/components/ShowUserAvatar.tsx
+++ b/frontend/src/components/ShowUserAvatar.tsx
@@ -3,9 +3,9 @@ import React from 'react';
 import { useParams } from 'react-router-dom';
 
 type UserAvatarProps = {
-  name?: string,
-  size?: number,
-}
+  name?: string;
+  size?: number;
+};
 
 const ShowUserAvatar: React.FC<UserAvatarProps> = ({ name, size }) => {
   // Get the first character of the username
@@ -16,11 +16,10 @@ const ShowUserAvatar: React.FC<UserAvatarProps> = ({ name, size }) => {
   if (!name) {
     let params = useParams<{ username?: string }>();
     username = params.username;
-  }
-  else {
+  } else {
     username = name;
   }
-  
+
   const firstCharacter: string | undefined = username
     ? username.charAt(0).toUpperCase()
     : undefined;
@@ -30,7 +29,11 @@ const ShowUserAvatar: React.FC<UserAvatarProps> = ({ name, size }) => {
     <Avatar
       size={finalSize}
       shape='square'
-      style={{ backgroundColor: '#fde3cf', color: '#f56a00', fontSize: `${finalSize/2}px` }}
+      style={{
+        backgroundColor: '#fde3cf',
+        color: '#f56a00',
+        fontSize: `${finalSize / 2}px`
+      }}
     >
       {firstCharacter}
     </Avatar>


### PR DESCRIPTION
This PR changes the behavior of reviews to show the review author's avatar as the review icon, instead of the book's icon.

Closes #52 

![image](https://github.com/COSC481W-2023Fall/Bookworm/assets/43181046/30f72548-dc18-43ab-8149-23ae69fa5aeb)
