### PR TITLE
fix: Broken fallback images for book covers

### DIFF
--- a/frontend/src/components/SearchDisplay.tsx
+++ b/frontend/src/components/SearchDisplay.tsx
@@ -65,7 +65,7 @@ export default function SearchDisplay() {
                 <Image
                   preview={false}
                   src={`https://covers.openlibrary.org/b/isbn/${book.isbn}-S.jpg`}
-                  fallback='../../public/image_not_available.png'
+                  fallback='../image_not_available.png'
                   width={40}
                 />
               </Link>

--- a/frontend/src/components/SearchDisplay.tsx
+++ b/frontend/src/components/SearchDisplay.tsx
@@ -71,7 +71,16 @@ export default function SearchDisplay() {
               </Link>
             }
             title={<Link to={`/book/${book.isbn}`}>{book.title}</Link>}
-            description={`Author:${book.author}`}
+            description={
+              <div>
+                Author: {book.author}
+                <br />
+                Publisher: {book.publisher}
+                <br />
+                Publication Date:{' '}
+                {book.publication_date.toString().substring(0, 10)}
+              </div>
+            }
           />
         </List.Item>
       )}

--- a/frontend/src/components/SearchDisplay.tsx
+++ b/frontend/src/components/SearchDisplay.tsx
@@ -64,7 +64,7 @@ export default function SearchDisplay() {
               <Link to={`/book/${book.isbn}`}>
                 <Image
                   preview={false}
-                  src={`https://covers.openlibrary.org/b/isbn/${book.isbn}-S.jpg`}
+                  src={`https://covers.openlibrary.org/b/isbn/${book.isbn}-S.jpg?default=false`}
                   fallback='../image_not_available.png'
                   width={40}
                 />

--- a/frontend/src/pages/BookView.tsx
+++ b/frontend/src/pages/BookView.tsx
@@ -51,7 +51,7 @@ function BookView(): JSX.Element {
               src={coverImageUrl}
               className={styles.image}
               width='300px'
-              fallback='../../public/image_not_available.png'
+              fallback='../image_not_available.png'
             />
             <div className={styles.ratingBox}>
               <Rate

--- a/frontend/src/pages/BookView.tsx
+++ b/frontend/src/pages/BookView.tsx
@@ -17,7 +17,7 @@ function BookView(): JSX.Element {
   const { isbn } = useParams<{ isbn: string }>();
   const [book, setBook] = useState<IBook | null>(null);
 
-  const coverImageUrl = `https://covers.openlibrary.org/b/isbn/${isbn}-L.jpg`;
+  const coverImageUrl = `https://covers.openlibrary.org/b/isbn/${isbn}-L.jpg?default=false`;
 
   useEffect(() => {
     async function fetchBook() {


### PR DESCRIPTION
Fixes our image covers so they show an image not available fallback image on missing covers. Also added some display data to search display.

Old:
![image](https://github.com/COSC481W-2023Fall/Bookworm/assets/99246929/3fd38a5b-f7e4-427d-beb1-bc02839e6c23)
![image](https://github.com/COSC481W-2023Fall/Bookworm/assets/99246929/d51f86e9-f1b1-4626-9725-5b7f291c718b)


New:
![image](https://github.com/COSC481W-2023Fall/Bookworm/assets/99246929/59b62294-ae3b-472c-8427-0cbc53fc38e5)
![image](https://github.com/COSC481W-2023Fall/Bookworm/assets/99246929/09b5de7f-ab2c-41cf-9f94-784b027930bd)


